### PR TITLE
set gogs tag to 0.9.97

### DIFF
--- a/xpaas/common/xpaas-gogs-persistent.yaml
+++ b/xpaas/common/xpaas-gogs-persistent.yaml
@@ -118,7 +118,7 @@ objects:
         version: "latest"
       from:
         kind: DockerImage
-        name: openshiftdemos/gogs:latest
+        name: openshiftdemos/gogs:0.9.97
       importPolicy: {}
       name: "latest"
 - apiVersion: v1

--- a/xpaas/common/xpaas-gogs-persistent.yaml
+++ b/xpaas/common/xpaas-gogs-persistent.yaml
@@ -115,12 +115,12 @@ objects:
     - annotations:
         description: The Gogs git server docker image
         tags: gogs,go,golang
-        version: "latest"
+        version: "0.9.97"
       from:
         kind: DockerImage
         name: openshiftdemos/gogs:0.9.97
       importPolicy: {}
-      name: "latest"
+      name: "0.9.97"
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -186,7 +186,7 @@ objects:
         - ${APPLICATION_NAME}
         from:
           kind: ImageStreamTag
-          name: ${APPLICATION_NAME}:latest
+          name: ${APPLICATION_NAME}:0.9.97
       type: ImageChange
   status: {}
 - apiVersion: v1


### PR DESCRIPTION
The "Introduction to Fuse Integration Services Lab" instructions [1] say

`$ oc exec $gogspod -- cat /etc/gogs/conf/app.ini > /tmp/gogs-app.ini`
`$ oc set volume dc/gogs --add --overwrite --name=config-volume -m /etc/gogs/conf/ --source='{"configMap":{"name":"gogs","items":[{"key":"gogs-app.ini","path":"app.ini"}]}}'`

The paths referenced are old, and don't represent the latest Gogs convention. The lab instructions will work, however, if the template specifies `gogs:0.9.97`.

Another option could be to point to a newer version of Gogs, and update instructions in the lab.

https://learning.redhat.com/course/view.php?id=805
