### PR TITLE
Updated initialDelaySeconds for probes

### DIFF
--- a/xpaas/common/xpaas-gogs-persistent.yaml
+++ b/xpaas/common/xpaas-gogs-persistent.yaml
@@ -145,7 +145,7 @@ objects:
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             httpGet:
@@ -160,7 +160,7 @@ objects:
           terminationMessagePath: /dev/termination-log
           readinessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             httpGet:


### PR DESCRIPTION
HTTP requests for repos in the UI returned 5xx errors with initialDelaySeconds set to 15, all fine when increased to 30.